### PR TITLE
Quickfix: change gem 'capybara-rspec' to gem 'capybara'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'sinatra'
 group :development do
   gem 'shotgun'
   gem 'rspec'
-  gem 'capybara-rspec'
+  gem 'capybara'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    capybara (2.2.1)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     diff-lcs (1.2.5)
+    mime-types (1.25.1)
+    mini_portile (0.5.2)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     rack (1.5.2)
     rack-protection (1.5.2)
       rack
+    rack-test (0.6.2)
+      rack (>= 1.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -20,11 +32,14 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     tilt (1.4.1)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   rspec
   shotgun
   sinatra


### PR DESCRIPTION
Correct wrong naming of capybara gem.
