### PR TITLE
Quickfix: change ./groundhog to ./groundhog_app in config.ru.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,2 @@
-require './groundhog'
+require './groundhog_app'
 run Sinatra::Application


### PR DESCRIPTION
- This should have changed when the name of the file changed.
- Requiring a non-existent file will cause the app to crash on Heroku.
