### PR TITLE
Quickfix: Change tests to reflect new submit button value.

### DIFF
--- a/spec/features/user_uploads_a_file_spec.rb
+++ b/spec/features/user_uploads_a_file_spec.rb
@@ -11,18 +11,18 @@ feature "User clicks upload" do
 
   scenario "and attached a valid file" do
     page.attach_file('video', 'spec/resources/grasshopper_test.mp4')
-    click_button("Upload!")
+    click_button("Make a gif!")
     expect(page.status_code).to be(200)
   end
 
   scenario "but did not attach a file", js: true do
-    click_button("Upload!")
+    click_button("Make a gif!")
     expect(page).to have_content('Please choose a file to upload.')
   end
 
   scenario "but attached an invalid file type" do
     page.attach_file('video', 'spec/resources/invalid.txt')
-    click_button("Upload!")
+    click_button("Make a gif!")
     expect(page.status_code).to be(406)
     expect(page).to have_content('Please upload a valid filetype.')
     expect(File.exist?('public/temp_video/invalid.txt')).to be_false
@@ -30,7 +30,7 @@ feature "User clicks upload" do
 
   scenario "the file should be saved to a temp_video folder" do
     page.attach_file('video', 'spec/resources/grasshopper_test.mp4')
-    click_button("Upload!")
+    click_button("Make a gif!")
     puts temp_video_path
     expect(File.exist?(temp_video_path)).to be_true
     File.delete(temp_video_path)
@@ -38,7 +38,7 @@ feature "User clicks upload" do
 
   scenario "the file should be converted to a gif" do
     page.attach_file('video', 'spec/resources/grasshopper_test.mp4')
-    click_button("Upload!")
+    click_button("Make a gif!")
     expect(File.exist?(temp_video_path)).to be_true
     File.delete(temp_gif_path)
   end


### PR DESCRIPTION
- Changing the button to say "Make a gif!" had broken a bunch of integration tests that looked for the value "Upload" when interacting with the page.
